### PR TITLE
Add logo component to footer

### DIFF
--- a/src/components/footer/Footer.module.scss
+++ b/src/components/footer/Footer.module.scss
@@ -5,4 +5,16 @@
   padding-top: 10vh;
   padding-bottom: 5vh;
   width: 100%;
+  text-align: center;
+}
+
+.logoContainer {
+  max-width: 50%;
+  margin-top: 77px;
+  margin: 0 auto;
+}
+
+.logoImage {
+  max-width: 50%;
+  padding-left: calc(5% - 10px);
 }

--- a/src/components/footer/Footer.module.scss
+++ b/src/components/footer/Footer.module.scss
@@ -8,13 +8,8 @@
   text-align: center;
 }
 
-.logoContainer {
-  max-width: 50%;
-  margin-top: 77px;
-  margin: 0 auto;
-}
-
 .logoImage {
-  max-width: 50%;
+  width: 197px;
+  height: 45px;
   padding-left: calc(5% - 10px);
 }

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -2,10 +2,11 @@ import * as React from 'react'
 import Container from '../Container'
 import FooterStyles from './Footer.module.scss'
 import Copyright from './Copyright'
+import Logo from '../navigation/logo/Logo'
 
 const Footer: React.FC = () => (
   <Container className={FooterStyles.container}>
-    <h1>CodingToast Footer</h1>
+    <Logo styles={FooterStyles} />
     <Copyright />
   </Container>
 )

--- a/src/components/footer/__tests__/__snapshots__/Footer.spec.tsx.snap
+++ b/src/components/footer/__tests__/__snapshots__/Footer.spec.tsx.snap
@@ -4,9 +4,9 @@ exports[`<Footer /> renders correctly 1`] = `
 <Container
   className="container"
 >
-  <h1>
-    CodingToast Footer
-  </h1>
+  <Logo
+    styles={null}
+  />
   <Copyright />
 </Container>
 `;

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -5,10 +5,11 @@ import NextSection from './NextSection'
 import HamburgerButton from './menu/HamburgerButton'
 import Container from '../Container'
 import NavigationStyles from './Navigation.module.scss'
+import LogoStyles from './logo/Logo.module.scss'
 
 const Navigation: React.FC = () => (
   <Container className={NavigationStyles.container}>
-    <Logo />
+    <Logo styles={LogoStyles} />
     <HamburgerButton />
     <QuoteBox />
     <NextSection />

--- a/src/components/navigation/logo/Logo.tsx
+++ b/src/components/navigation/logo/Logo.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react'
 import LogoImage from '../../../images/logo.svg'
-import LogoStyles from './Logo.module.scss'
 
-const Logo: React.FC = () => (
-  <div className={LogoStyles.logoContainer}>
-    <img className={LogoStyles.logoImage} src={LogoImage} alt="coding toast" />
-  </div>
-)
+interface StyleProps {
+  styles: CSSModule
+}
+
+const Logo: React.FC<StyleProps> = props => {
+  const { styles } = props
+  return (
+    <div className={styles.logoContainer}>
+      <img className={styles.logoImage} src={LogoImage} alt="coding toast" />
+    </div>
+  )
+}
 
 export default Logo

--- a/src/components/navigation/logo/__tests__/Logo.spec.tsx
+++ b/src/components/navigation/logo/__tests__/Logo.spec.tsx
@@ -2,10 +2,11 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import toJson from 'enzyme-to-json'
 import Logo from '../Logo'
+import LogoStyles from '../Logo.module.scss'
 
 describe('<Logo />', () => {
   it('renders correctly', () => {
-    const component = shallow(<Logo />)
+    const component = shallow(<Logo styles={LogoStyles} />)
     expect(toJson(component)).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
issue #54 

**Description**
Add logo component to footer

![Screenshot_2020-04-29 gatsby-starter-typescript-plus(1)](https://user-images.githubusercontent.com/12180220/80652646-34aaed80-8a2d-11ea-95af-dfe556ee9744.png)


**Checklist (check all that is appropriate)**
- [X] Issue is linked in this PR
- [X] Existing tests pass
- [ ] Accessibility tested (if appropriate)
