### PR TITLE
Add terms of service and privacy policy links to footer component

### DIFF
--- a/src/components/footer/Copyright.tsx
+++ b/src/components/footer/Copyright.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react'
+import FooterStyles from './Footer.module.scss'
 
 const Copyright: React.FC = () => (
-  <>
-    <p>
+  <div>
+    <p className={FooterStyles.copyright}>
       &copy; {new Date().getFullYear()} Coding Toast
       <br />
       Quentin Guenther, Nathan Corbin
     </p>
-  </>
+  </div>
 )
 
 export default Copyright

--- a/src/components/footer/Footer.module.scss
+++ b/src/components/footer/Footer.module.scss
@@ -13,3 +13,23 @@
   height: 45px;
   padding-left: calc(5% - 10px);
 }
+
+.leftAlign {
+  float: left;
+}
+
+.rightAlign {
+  float: right;
+}
+
+.links {
+  padding: 48px 16px 32px 16px;
+}
+
+.copyright, a {
+  color: $text-color-disabled;
+}
+
+a {
+  text-decoration: none;
+}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -3,10 +3,12 @@ import Container from '../Container'
 import FooterStyles from './Footer.module.scss'
 import Copyright from './Copyright'
 import Logo from '../navigation/logo/Logo'
+import Policies from './Policies'
 
 const Footer: React.FC = () => (
   <Container className={FooterStyles.container}>
     <Logo styles={FooterStyles} />
+    <Policies />
     <Copyright />
   </Container>
 )

--- a/src/components/footer/Policies.tsx
+++ b/src/components/footer/Policies.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+import { Link } from 'gatsby'
+import FooterStyles from './Footer.module.scss'
+
+const Policies: React.FC = () => {
+  return (
+    <div className={FooterStyles.links}>
+      <Link to="/" className={FooterStyles.leftAlign}>
+        Privacy Policy
+      </Link>
+      <Link to="/" className={FooterStyles.rightAlign}>
+        Terms of Service
+      </Link>
+    </div>
+  )
+}
+
+export default Policies

--- a/src/components/footer/__tests__/__snapshots__/Copyright.spec.tsx.snap
+++ b/src/components/footer/__tests__/__snapshots__/Copyright.spec.tsx.snap
@@ -1,13 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Copyright /> renders correctly 1`] = `
-<Fragment>
-  <p>
+<div>
+  <p
+    className="copyright"
+  >
     © 
     2020
      Coding Toast
     <br />
     Quentin Guenther, Nathan Corbin
   </p>
-</Fragment>
+</div>
 `;

--- a/src/components/footer/__tests__/__snapshots__/Footer.spec.tsx.snap
+++ b/src/components/footer/__tests__/__snapshots__/Footer.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`<Footer /> renders correctly 1`] = `
   <Logo
     styles={null}
   />
+  <Policies />
   <Copyright />
 </Container>
 `;


### PR DESCRIPTION
issue #55

**Description**
Add terms of service and privacy policy links to footer component

**Screenshots and Gifs (if appropriate)**
![Screenshot_2020-04-30 gatsby-starter-typescript-plus(1)](https://user-images.githubusercontent.com/12180220/80740517-0bda3500-8acd-11ea-86b2-74330e2793d9.png)


**Checklist (check all that is appropriate)**
- [X] Issue is linked in this PR
- [X] Existing tests pass
- [ ] Accessibility tested (if appropriate)
